### PR TITLE
update nan to v1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"install" : "node-gyp rebuild"
 	},
 	"dependencies" : {
-		"nan" : "~1.0.0"
+		"nan" : "~1.7.0"
 	},
 	"gypfile"     : true
 }


### PR DESCRIPTION
Update the nan dependency to v1.7.0, so gc-stats builds on current
node.js/io.js versions.

I tested this with node.js v0.12.0, v0.10.36 and io.js v1.5.1 on Linux,
seems to work fine there (apart from a few deprecation warnings during
the build). Actively using it in a project running on io.js (v1.3.0 at
the moment) without any issues so far.

Don't know if or how well it works on Windows or MacOS, as I currently
don't have suitable environments to test that.