### PR TITLE
Add Travis CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # GCStats
+[![Build Status](https://travis-ci.org/dainis/node-gcstats.svg?branch=master)](https://travis-ci.org/dainis/node-gcstats)
 
 Exposes stats about V8 GC after it has been executed.
 


### PR DESCRIPTION
Considering that `node-gcstats` depends on compiled assets, it would be great to know which Node versions it is tested with. Providing on click access to Travis makes this easier.