### PR TITLE
Eliminate bind(), emit `stats` right after `data`

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,12 +8,11 @@ function GCStats() {
 		gcEmitter = new EventEmitter();
 		gcstats.afterGC(function(stats) {
 			gcEmitter.emit('data', stats);
+			gcEmitter.emit('stats', stats);
 		});
 	}
 
 	EventEmitter.call(this);
-
-	gcEmitter.on('data', this.emit.bind(this, 'stats'));
 }
 
 util.inherits(GCStats, EventEmitter);


### PR DESCRIPTION
The `data` and `stats` events are the exact same event. Instead of binding an event to an event, just emit both one after the other.

This also solves an event emitter leak we're seeing.

cc/ @rf @raynos