### PR TITLE
Replace constructor w/ Singleton; Use bindings module;

### DIFF
--- a/binding.js
+++ b/binding.js
@@ -1,0 +1,2 @@
+'use strict';
+module.exports = require('bindings')('gcstats.node');

--- a/index.js
+++ b/index.js
@@ -1,21 +1,19 @@
 var gcEmitter,
-	util = require('util'),
 	gcstats = require('./build/Release/gcstats'),
 	EventEmitter = require('events').EventEmitter;
 
-function GCStats() {
+function gcStats() {
+	if (this instanceof gcStats){
+        	throw Error('gc-stats no longer exports a constructor. Call without the `new` keyword');
+   	}
 	if(!gcEmitter) {
 		gcEmitter = new EventEmitter();
 		gcstats.afterGC(function(stats) {
 			gcEmitter.emit('data', stats);
+			gcEmitter.emit('stats', stats);
 		});
 	}
-
-	EventEmitter.call(this);
-
-	gcEmitter.on('data', this.emit.bind(this, 'stats'));
+	return gcEmitter;
 }
 
-util.inherits(GCStats, EventEmitter);
-
-module.exports = GCStats;
+module.exports = gcStats;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var gcEmitter,
-	gcstats = require('./build/Release/gcstats'),
+	gcstats = require('bindings')('gcstats.node'),
 	EventEmitter = require('events').EventEmitter;
 
 function gcStats() {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "./node_modules/mocha/bin/mocha --expose-gc ./tests"
   },
   "dependencies": {
+    "bindings": "^1.2.1",
     "nan": "^2.0.5"
   },
   "gypfile": true,

--- a/tests/gc-stats.test.js
+++ b/tests/gc-stats.test.js
@@ -12,7 +12,7 @@ describe('gc-stats', function() {
 	var gcStats;
 
 	beforeEach(function() {
-		gcStats = new GCStats();
+		gcStats = GCStats();
 	});
 
 	it('should emit stats event with object containing gc stats', function(done) {


### PR DESCRIPTION
This PR contains a few improvements and is a backwards incompatible change requiring a major version bump:

1) Eliminate the constructor pattern and prefer a singleton pattern. This eliminates the double emitting of events from the private singleton emitter to the class. We encountered a too many event emitters error because of this. The alternative would have been to up the max event emitters, but this seemed like a better option;
2) Exposing gcEmitter as a singleton, means that the stats event now needs to be emitted on gcEmitter;
3) Use the 'bindings' module. This module makes sure that you can always require the gc-stats bindings regardless of how it was built.
4) Add a bindings.js file that allows someone to use the bindings directly instead of through index.js.

If you don't like these changes, I'm happy to submit the bindings improvement and bindings.js file as its own pull request. 

cc/ @rf @raynos